### PR TITLE
Added qucs print report generator, with comparison output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ To skip failing projects use the `--skip` option with a list of projects to be i
 ## Options: `python run.py -h`
 
 ```
-usage: run.py [-h] [--prefix PREFIX] [--qucs] [--qucsator] [-p]
-              [--add-test ADD_TEST] [--exclude EXCLUDE] [--include INCLUDE]
-              [--project PROJECT]
-              [--compare-qucsator COMPARE_QUCSATOR [COMPARE_QUCSATOR ...]]
-              [-v [VERBOSE]] [--reset] [--timeout TIMEOUT] [--rtol RTOL]
+usage: run.py [-h] [--prefix PREFIX] [--qucs] [--qucsator]
+              [-p [{sch,dpl,all}]] [--add-test FILE] [--exclude FILE]
+              [--include FILE] [--project PROJECT] [--compare PATH [PATH ...]]
+              [-v [LEVEL]] [--reset] [--timeout TIMEOUT] [--rtol RTOL]
               [--atol ATOL] [--plot-interactive] [-mp [NUM]]
 
 Qucs testing script.
@@ -25,15 +24,17 @@ optional arguments:
   --prefix PREFIX       prefix of installed Qucs (default: /usr/local/bin/)
   --qucs                run qucs tests
   --qucsator            run qucsator tests
-  -p                    run qucs and prints the schematic to file
-  --add-test ADD_TEST   add schematic to the testsuite
-  --exclude EXCLUDE     file listing projects excluded from test
-  --include INCLUDE     file of project selected for test
+  -p [{sch,dpl,all}], --print [{sch,dpl,all}]
+                        run qucs and prints schematics and/or data displays to
+                        file
+  --add-test FILE       add schematic file to the testsuite
+  --exclude FILE        file listing projects excluded from test
+  --include FILE        file listing projects selected for test
   --project PROJECT     path to a test project
-  --compare-qucsator COMPARE_QUCSATOR [COMPARE_QUCSATOR ...]
-                        two full paths to directories containing qucsator
-                        binaries for comparison test
-  -v [VERBOSE], --verbose [VERBOSE]
+  --compare PATH [PATH ...]
+                        two full paths to directories containing qucs or
+                        qucsator binaries for comparison test
+  -v [LEVEL], --verbose [LEVEL]
                         increase verbosity: 0 = only warnings, 1 = info, 2 =
                         debug. No number means info. Default is no verbosity.
   --reset               Reset (overwrite) data and log files of test
@@ -72,20 +73,40 @@ The test can be run using several processes in parallel, which will shorthen the
 $python run.py --prefix /home/user/local/qucs-master/bin/ --exclude skip.txt --qucsator -mp
 ```
 
+Two different `qucsator` versions can be compared with the command:
+
+```
+$ python run.py --compare /home/user/bin1/ /home/user/bin2/ --qucsator -mp
+```
+
+where `/home/user/bin1/` and `/home/user/bin2/` are the two directories containing the `qucsator` binaries to be tested.
+
 ## Printing the schematic to PDF files (devel)
 
 See below examples of printing schematics to file (pdf):
 
  * printing all
- * skipking a list of projects
+ * printing all data display (`.dpl`) files only
+ * skipping a list of projects
  * a single project from the testsuite
 
 ```
-$python run.py --prefix /home/user/local/qucs-master/bin/ --p
-$python run.py --prefix /home/user/local/qucs-master/bin/ --exclude skip_print.txt -p
-$python run.py --prefix /home/user/local/qucs-master/bin/ --p --project AC_SW_resonance_prj
+$python run.py --prefix /home/user/local/qucs-master/bin/ --print
+$python run.py --prefix /home/user/local/qucs-master/bin/ --print dpl
+$python run.py --prefix /home/user/local/qucs-master/bin/ --exclude skip_print.txt -print
+$python run.py --prefix /home/user/local/qucs-master/bin/ --print --project AC_SW_resonance_prj
 ```
 
+As for the `qucsator` test, the `-mp` option can be added to run multiple (printing) processes in parallel.
+
+The script will generate a table showing, for every file, the time needed to print the schematics to file or the `qucs` error code in case the file generation was not succesful.
+
+Two different `qucs` versions can be used to generate the print files and the results for every binary will be shown in the report table, to allow for a quick comparison. Use a command like:
+
+```
+$ python run.py --compare /home/user/bin1/ /home/user/bin2/ --print -mp
+```
+where `/home/user/bin1/` and `/home/user/bin2/` are the two directories containing the `qucs` binaries to be tested.
 
 
 ## Running the Qucs equations tests
@@ -103,10 +124,24 @@ In short, it works as follows:
 - Run the netlist and read the simulator output.
 - Compare simulator output to the expected result.
 
-Run it with:
+
+### Options: `python run_equations.py -h`
+````
+usage: run_equations.py [-h] [--prefix PREFIX] [--operation OPERATION]
+
+Qucs testing script.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --prefix PREFIX       prefix of installed Qucs (default: /usr/local/bin/)
+  --operation OPERATION
+                        test one particular operation, ex. '+')
+````
+
+To run all the tests, use:
 
 ```
-$ python run_equations.py /home/user/git/qucs-clone/
+$ python run_equations.py --prefix /home/user/git/qucs-clone/
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ To skip failing projects use the `--skip` option with a list of projects to be i
 
 ```
 usage: run.py [-h] [--prefix PREFIX] [--qucs] [--qucsator] [-p]
-              [--add-test ADD_TEST] [--skip SKIP] [--project PROJECT]
+              [--add-test ADD_TEST] [--exclude EXCLUDE] [--include INCLUDE]
+              [--project PROJECT]
               [--compare-qucsator COMPARE_QUCSATOR [COMPARE_QUCSATOR ...]]
-              [-v [VERBOSE]] [--reset] [--timeout TIMEOUT]
+              [-v [VERBOSE]] [--reset] [--timeout TIMEOUT] [--rtol RTOL]
+              [--atol ATOL] [--plot-interactive] [-mp [NUM]]
 
 Qucs testing script.
 
@@ -25,17 +27,27 @@ optional arguments:
   --qucsator            run qucsator tests
   -p                    run qucs and prints the schematic to file
   --add-test ADD_TEST   add schematic to the testsuite
-  --skip SKIP           file listing skipped test projects
+  --exclude EXCLUDE     file listing projects excluded from test
+  --include INCLUDE     file of project selected for test
   --project PROJECT     path to a test project
   --compare-qucsator COMPARE_QUCSATOR [COMPARE_QUCSATOR ...]
                         two full paths to directories containing qucsator
                         binaries for comparison test
   -v [VERBOSE], --verbose [VERBOSE]
-                        increase verbosity: 0 = progress and errors, 1 = all
-                        info. Default is low verbosity.
+                        increase verbosity: 0 = only warnings, 1 = info, 2 =
+                        debug. No number means info. Default is no verbosity.
   --reset               Reset (overwrite) data and log files of test
                         projects.Run qucsator given with --prefix.
-  --timeout TIMEOUT     Abort test if longer that timeout (default: 15 s).
+  --timeout TIMEOUT     Abort test if longer that timeout (default: 90 s).
+  --rtol RTOL           Set the element-wise relative tolerace (default 1e-1).
+                        See: Numpy allclose function.
+  --atol ATOL           Set the element-wise absolute tolerace (default 1e-5).
+                        See: Numpy allclose function.
+  --plot-interactive    Plot and show error graphs interactively. Hardcopy PNG
+                        saved by default.
+  -mp [NUM], --processes [NUM]
+                        Use NUM processes to run the simulations (default:
+                        number of CPU cores).
 ```
 
 ## Outputs
@@ -51,9 +63,14 @@ optional arguments:
 Example of running the test-suite for Qucsator while skipping a few test projects:
 
 ```
-$python run.py --prefix /home/user/local/qucs-master/bin/ --skip skip.txt --qucsator
+$python run.py --prefix /home/user/local/qucs-master/bin/ --exclude skip.txt --qucsator
 ```
 
+The test can be run using several processes in parallel, which will shorthen the overall simulation time if the machine has a multi-core processor, using the `-mp` option
+
+```
+$python run.py --prefix /home/user/local/qucs-master/bin/ --exclude skip.txt --qucsator -mp
+```
 
 ## Printing the schematic to PDF files (devel)
 
@@ -65,7 +82,7 @@ See below examples of printing schematics to file (pdf):
 
 ```
 $python run.py --prefix /home/user/local/qucs-master/bin/ --p
-$python run.py --prefix /home/user/local/qucs-master/bin/ --skip skip_print.txt -p
+$python run.py --prefix /home/user/local/qucs-master/bin/ --exclude skip_print.txt -p
 $python run.py --prefix /home/user/local/qucs-master/bin/ --p --project AC_SW_resonance_prj
 ```
 

--- a/qucstest/qucsgui.py
+++ b/qucstest/qucsgui.py
@@ -16,7 +16,14 @@ def get_qucs_version(prefix):
     '''
     cmd = [prefix + "qucs", "-v"]
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    version = p.stdout.readlines()[0].strip()
+    p_out = p.stdout.readlines()
+    # need to look for a line starting with 'Qucs'
+    #   as there might be some GTK+ junk output before (?)
+    #   like "Gtk-WARNING **: Locale not supported by C library."
+    version = '(unknown)'
+    for line in p_out:
+        if line.startswith('Qucs'):
+            version = line.strip()
     return version
 
 

--- a/qucstest/qucsgui.py
+++ b/qucstest/qucsgui.py
@@ -14,7 +14,7 @@ def get_qucs_version(prefix):
     :param prefix: path to qucsator executable
     :return: the version tag of qucsator
     '''
-    cmd = [prefix + "qucs", "-v"]
+    cmd = [os.path.join(prefix,"qucs"), "-v"]
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     p_out = p.stdout.readlines()
     # need to look for a line starting with 'Qucs'

--- a/qucstest/report.py
+++ b/qucstest/report.py
@@ -169,3 +169,76 @@ def report_coverage(collection, datafile, report_name=''):
             rep_file.write(cov_report)
 
     return cov_report
+
+
+def report_print_status(collection, savename='', footer=''):
+    '''
+    Print a table with printing test results. It can also write to file.
+
+    :param collection: data collected during printing tests.
+    :param savename: name used to save the table to a text file.
+    :param footer: custom footer appended to the table.
+    :return: None
+    '''
+    header = '%-30s | %-15s ' %('Project', 'Schem. Version')
+
+    for testrun in collection:
+        header += ' |   Print Runtime    '
+
+    line = '-'*len(header)
+
+    if savename:
+        f = open(savename, 'w')
+        f.write(line+'\n')
+        f.write(header+'\n')
+        f.write(line+'\n')
+
+    print line
+    print header
+    print line
+
+    names = []
+    versions = []
+    results = []
+
+    for test_idx, test in enumerate(collection[0]): # project names
+        if test.files: # project not empty
+            proj_stat = '%-30s | %-15s  | %-20s' %(test.name, '', '')
+            if (len(collection) > 1): # used --compare
+                proj_stat += '| %-20s' %('')
+            print proj_stat
+            for sch_idx, sch in enumerate(test.files):
+                proj_stat = '  %-28s | %-15s  ' %(sch.name, sch.version)
+                if 'NUM_FAIL' in sch.status:
+                    proj_stat += '| %-10s' %(str(sch.runtime))
+                    proj_stat += '%s' %('NUM_FAIL  ')
+                elif 'FAIL' in sch.status:
+                    proj_stat += '| %-20s' %(sch.status)
+                else:
+                    proj_stat += '| %-20s' %(str(sch.runtime))
+                if (len(collection) > 1): # used --compare
+                    sch = collection[1][test_idx].files[sch_idx]
+                    if 'NUM_FAIL' in sch.status:
+                        proj_stat += '| %-10s' %(str(sch.runtime))
+                        proj_stat += '%s' %('NUM_FAIL  ')
+                    elif 'FAIL' in sch.status:
+                        proj_stat += '| %-20s' %(sch.status)
+                    else:
+                        proj_stat += '| %-20s' %(str(sch.runtime))
+                # report line
+                print proj_stat
+
+                if savename:
+                    f.write(proj_stat+'\n')
+
+    if footer:
+        print line
+        f.write(line+'\n')
+        print footer
+        f.write(footer)
+
+    if savename:
+        print line
+        f.write(line+'\n')
+        f.close()
+        print pg("Saved simulation report: %s " %savename)

--- a/run_equations.py
+++ b/run_equations.py
@@ -622,7 +622,7 @@ if __name__ == '__main__':
                 myTest.write( net )
 
             testCount +=1
-            cmd = [prefix+"qucsator", "-i", inNet, "-o", outDat]
+            cmd = [os.path.join(prefix, "qucsator"), "-i", inNet, "-o", outDat]
             command = Command(cmd)
             command.run(timeout=1)
 


### PR DESCRIPTION
I have expanded the print function to generate a small report, similar to the one used for `qucsator`, in order to have a summary of the results and check easily if some of the print failed.
Similarly, two `qucs` versions can be compared for the print output. At present there is no reference result for printing, but only the comparison table is generated. Not sure how we could compare the print output, as we should probably allow for some "fuzzy factor". I have also fixed a couple of small things around.

The comparison report for print looks like this:

```
*****************************
* Qucs printing test report *
*****************************
---------------------------------------------------------------------------------------------
Project                        | Schem. Version   |   Print Runtime     |   Print Runtime    
---------------------------------------------------------------------------------------------
AC_SW_resonance_prj            |                  |                     |                     
  resonance.sch                | 0.0.4            | 0.216293            | 0.164690            
AC_SW_swr_meter_prj            |                  |                     |                     
  swr_meter.sch                | 0.0.4            | 0.213962            | 0.165291            
AC_bandpass_prj                |                  |                     |                     
  bandpass.sch                 | 0.0.17           | FAIL (-11)          | FAIL (-11)          
  opa227.sch                   | 0.0.17           | 0.114141            | 0.113669            
  bandpass.dpl                 | 0.0.17           | 0.113685            | 0.113746            
AC_groupdelay_ac_prj           |                  |                     |                     
  groupdelay_ac.sch            | 0.0.12           | 0.165728            | 0.164440            
DC_AC_LM358_spice_prj          |                  |                     |                     
  LM358_spice.sch              | 0.0.17           | 0.215737            | 0.164068            
DC_AC_SP_stab_prj              |                  |                     |                     
  stab.sch                     | 0.0.4            | 0.215052            | 0.164092            
DC_AC_active_bp_prj            |                  |                     |                     
  active_bp.sch                | 0.0.5            | 0.214313            | 0.164478            
DC_AC_active_lp_prj            |                  |                     |                     
  active_lp.sch                | 0.0.5            | 0.215293            | 0.164474            
DC_AC_bbv_prj                  |                  |                     |                     
  bbv.sch                      | 0.0.5            | 0.113781            | 0.113616            
DC_AC_gain_prj                 |                  |                     |                     
  gain.sch                     | 0.0.5            | FAIL (-11)          | FAIL (-11)          
  singleOPV.sch                | 0.0.5            | 0.113681            | 0.113683            
DC_AC_gyrator_prj              |                  |                     |                     
  gyrator.sch                  | 0.0.4            | 0.115023            | 0.113613            
DC_AC_notch_prj                |                  |                     |                     
  notch.sch                    | 0.0.5            | 0.114538            | 0.113627            
DC_AC_selective_amp_prj        |                  |                     |                     
  selective_amp.sch            | 0.0.5            | 0.113716            | 0.113720            
DC_SP_HICUM-fig10_prj          |                  |                     |                     
  HICUM-fig10.sch              | 0.0.11           | 0.113677            | 0.163706            
DC_SP_LPF-Balun2_prj           |                  |                     |                     
  IdealBalun.sch               | 0.0.15           | 0.113839            | 0.113671            
  LPF-Balun2.sch               | 0.0.15           | FAIL (-11)          | FAIL (-11)          
DC_SP_LPF-Balun3_prj           |                  |                     |                     
  LPF-Balun3.sch               | 0.0.15           | 0.113920            | 0.113636            
DC_SP_opamp_gyrator_prj        |                  |                     |                     
  opamp_gyrator.sch            | 0.0.5            | 0.113689            | 0.113649            
DC_SW_bridge_prj               |                  |                     |                     
  bridge.sch                   | 0.0.3            | 0.114054            | 0.113627            
DC_SW_bsim4v30nMOS_Ids_Vgs_prj |                  |                     |                     
  bsim4v30nMOS_Ids_Vgs.sch     | 0.0.18           | 0.163736            | 0.164028            
DC_SW_bsim4v30pMOS_Ids_Vgs_prj |                  |                     |                     
  bsim4v30pMOS_Ids_Vgs.sch     | 0.0.18           | 0.163739            | 0.163938            
DC_SW_charac_prj               |                  |                     |                     
  charac.sch                   | 0.0.4            | 0.113873            | 0.113716            
DC_SW_curtice_1_tb1_prj        |                  |                     |                     
  curtice_1_tb1.sch            | 0.0.18           | FAIL (-11)          | FAIL (-11)          
DC_SW_diff1_prj                |                  |                     |                     
  diff1.sch                    | 0.0.5            | 0.113760            | 0.113660            
DC_SW_diode_prj                |                  |                     |                     
  diode.sch                    | 0.0.18           | 0.165447            | 0.163946            
DC_SW_fgummel_prj              |                  |                     |                     
  fgummel.sch                  | 0.0.10           | 0.113723            | 0.113653            
DC_SW_preregulator_prj         |                  |                     |                     
  preregulator.sch             | 0.0.15           | 0.113710            | 0.113663            
DC_SW_rgummel_prj              |                  |                     |                     
  rgummel.sch                  | 0.0.10           | 0.113635            | 0.113772            
DC_TR_LM358_spice_prj          |                  |                     |                     
  LM358_spice.sch              | 0.0.17           | 0.113698            | 0.113687            
DC_TR_SW_TestHBProbe_prj       |                  |                     |                     
  TestHBProbe.sch              | 0.0.18           | 0.113705            | 0.113965            
DC_TR_SW_spice_BFR520_prj      |                  |                     |                     
  BFR520_sub.sch               | 0.0.17           | 0.113797            | 0.113722            
  spice_BFR520.sch             | 0.0.18           | FAIL (-11)          | FAIL (-11)          
DC_TR_active_mixer_prj         |                  |                     |                     
  active_mixer.sch             | 0.0.4            | 0.114606            | 0.114044            
SP_SmithChartTest_prj          |                  |                     |                     
  SmithChartTest.sch           | 0.0.12           | 0.113842            | 0.113734            
SP_Sparam_diagrams_prj         |                  |                     |                     
  Sparam_diagrams.sch          | 0.0.18           | FAIL (-6)           | 0.164026            
SP_bpf_10Ghz_prj               |                  |                     |                     
  bpf_10Ghz.sch                | 0.0.4            | 0.114995            | 0.113786            
SP_chebyshev1_5th_prj          |                  |                     |                     
  chebyshev1_5th.sch           | 0.0.3            | 0.114964            | 0.121085            
SP_elliptic_5th_prj            |                  |                     |                     
  elliptic_5th.sch             | 0.0.3            | 0.114908            | 0.116207            
SP_fet_noise_prj               |                  |                     |                     
  fet.sch                      | 0.0.5            | 0.113714            | 0.113770            
  fet_noise.sch                | 0.0.5            | FAIL (-11)          | FAIL (-11)          
SP_fhr01fh_prj                 |                  |                     |                     
  fhr01fh.sch                  | 0.0.3            | 0.113657            | 0.115050            
SP_giacoletto_prj              |                  |                     |                     
  giacoletto.sch               | 0.0.3            | 0.113726            | 0.114350            
SP_groupdelay_sp_prj           |                  |                     |                     
  groupdelay_sp.sch            | 0.0.12           | 0.113748            | 0.114636            
SP_microstrip_prj              |                  |                     |                     
  microstrip.sch               | 0.0.4            | 0.114486            | 0.113719            
SP_mscoupler_prj               |                  |                     |                     
  mscoupler.sch                | 0.0.7            | 0.113625            | 0.114647            
SP_sparam_prj                  |                  |                     |                     
  sparam.sch                   | 0.0.17           | FAIL (-6)           | 0.113730            
SP_wilkinson_prj               |                  |                     |                     
  wilkinson.sch                | 0.0.5            | 0.113731            | 0.114660            
TR_555_Fig7_prj                |                  |                     |                     
  555_Fig7.sch                 | 0.0.17           | FAIL (-11)          | FAIL (-11)          
  timer_555.sch                | 0.0.17           | FAIL (-11)          | FAIL (-11)          
  timer_Discharge.sch          | 0.0.17           | 0.113693            | 0.113772            
  timer_amp.sch                | 0.0.17           | 0.113866            | 0.113792            
  timer_digital_comb.sch       | 0.0.17           | 0.114453            | 0.114752            
  timer_thresh.sch             | 0.0.17           | 0.064304            | 0.063676            
  timer_trig.sch               | 0.0.17           | 0.113798            | 0.064353            
  555_Fig7.dpl                 | 0.0.17           | 0.063717            | 0.063740            
TR_555_Fig9_prj                |                  |                     |                     
  555_Fig9.sch                 | 0.0.17           | FAIL (-11)          | FAIL (-11)          
  timer_555.sch                | 0.0.17           | FAIL (-11)          | FAIL (-11)          
  timer_Discharge.sch          | 0.0.17           | 0.113738            | 0.115738            
  timer_amp.sch                | 0.0.17           | 0.115106            | 0.113687            
  timer_digital_comb.sch       | 0.0.17           | 0.113700            | 0.113741            
  timer_thresh.sch             | 0.0.17           | 0.113728            | 0.063718            
  timer_trig.sch               | 0.0.17           | 0.063707            | 0.063702            
TR_Puls3b_prj                  |                  |                     |                     
  Puls3b.sch                   | 0.0.17           | 0.114708            | 0.114399            
TR_boostconverter_prj          |                  |                     |                     
  boostconverter.sch           | 0.0.15           | 0.113649            | 0.113696            
TR_buckboost_prj               |                  |                     |                     
  buckboost.sch                | 0.0.15           | 0.113570            | 0.113769            
TR_buckconverter_prj           |                  |                     |                     
  buckconverter.sch            | 0.0.15           | 0.113858            | 0.113658            
TR_chargepump_prj              |                  |                     |                     
  chargepump.sch               | 0.0.5            | 0.113694            | 0.114405            
TR_classic_osci_prj            |                  |                     |                     
  classic_osci.sch             | 0.0.4            | 0.113704            | 0.113786            
TR_colpitts_base_prj           |                  |                     |                     
  colpitts_base.sch            | 0.0.5            | 0.113730            | 0.114393            
TR_colpitts_prj                |                  |                     |                     
  colpitts.sch                 | 0.0.4            | 0.113705            | 0.114057            
TR_diode_hb_prj                |                  |                     |                     
  diode_hb.sch                 | 0.0.9            | 0.113827            | 0.113792            
TR_fullwaverectifier_1_prj     |                  |                     |                     
  fullwaverectifier_1.sch      | 0.0.15           | 0.113704            | 0.113701            
TR_fullwaverectifier_2_prj     |                  |                     |                     
  fullwaverectifier_2.sch      | 0.0.15           | 0.115469            | 0.115593            
TR_gilbert_prj                 |                  |                     |                     
  gilbert.sch                  | 0.0.4            | 0.113721            | 0.113780            
TR_lc_osc_prj                  |                  |                     |                     
  lc_osc.sch                   | 0.0.12           | 0.114060            | 0.113789            
TR_lf_osci_prj                 |                  |                     |                     
  lf_osci.sch                  | 0.0.4            | 0.163798            | 0.113619            
TR_mixer_prj                   |                  |                     |                     
  mixer.sch                    | 0.0.4            | 0.114487            | 0.114094            
TR_multiplier_prj              |                  |                     |                     
  multiplier.sch               | 0.0.4            | 0.113682            | 0.113708            
TR_resistor_prj                |                  |                     |                     
  resistor.sch                 | 0.0.18           | 0.113733            | 0.113698            
TR_rf_osci_prj                 |                  |                     |                     
  rf_osci.sch                  | 0.0.4            | 0.113665            | 0.114854            
TR_sawtooth-1_prj              |                  |                     |                     
  sawtooth-1.sch               | 0.0.10           | 0.113874            | 0.114424            
TR_sawtooth-2_prj              |                  |                     |                     
  sawtooth-2.sch               | 0.0.10           | 0.113684            | 0.113768            
TR_sawtooth-3_prj              |                  |                     |                     
  sawtooth-3.sch               | 0.0.17           | 0.113944            | 0.113764            
TR_sawtooth-discreet_prj       |                  |                     |                     
  sawtooth-discreet.sch        | 0.0.17           | 0.163789            | 0.113799            
TR_schmitt_prj                 |                  |                     |                     
  schmitt.sch                  | 0.0.5            | 0.113740            | 0.114072            
TR_single_balanced_prj         |                  |                     |                     
  single_balanced.sch          | 0.0.12           | 0.113740            | 0.115923            
TR_supply_prj                  |                  |                     |                     
  supply.sch                   | 0.0.5            | 0.113737            | 0.115015            
TR_sym_osci_prj                |                  |                     |                     
  sym_osci.sch                 | 0.0.4            | 0.120292            | 0.113762            
---------------------------------------------------------------------------------------------
Qucs versions:   Qucs 0.0.19 (8055078) : Qucs 0.0.19 (a16372c) : 

Binary Locations:
/usr/bin
/home/user/qucs-git/qucs/qucs

Report produced on: 2015-07-05 22:06:14

---------------------------------------------------------------------------------------------
Saved simulation report: qucs_comparison_150705_220614_print_results.txt 
```

the comparison is between the current `qucs` and the one before https://github.com/felix-salfelder/qucs/commit/dbd3376652d815bea86bb0a142f8012386d6db7f and you can see the failing S-parameters diagram printing there.

The overall code is not really nice but seems to work. It seems I didn't break anything in the existing code, but please double check.

