### PR TITLE
Enable running qucs-test using the Windows python

### DIFF
--- a/qucstest/report.py
+++ b/qucstest/report.py
@@ -115,7 +115,7 @@ def report_coverage(collection, datafile, report_name=''):
         print pr('Problem finding: %s' %datafile)
         print pr('  Run "parse_models.py"')
         return
-    data = pickle.load( open( datafile, "rb" ) )
+    data = pickle.load( open( datafile, "r" ) )
 
     reg = [
     '  REGISTER_LUMPED',


### PR DESCRIPTION
some small modifications to be able to run qucs-test using the Windows python (from the `cmd` shell)

I took the easiest route, disabling `multiprocessing` on Windows, as it is quite difficult to make it work properly (tried a little, but did not get much far).
See, e.g. http://stackoverflow.com/questions/9670926/multiprocessing-on-windows-breaks
We do not use `multiprocessing` for testing on AppVeyor anyway...

With these modifications, I just need to add the `mingw64` libraries to the path,
```
set PATH=%PATH%;c:\msys64\mingw64\bin
```
and then I can run the tests as usual
```
C:\tmp\qucs-test>python run.py --prefix /msys64/usr/local/bin --qucsator --exclude skip.txt
```

note that I have some `NUM_FAIL` on Win, but this is another story...