### PR TITLE
Silence random errors on OSX.

### DIFF
--- a/skip_OSX.txt
+++ b/skip_OSX.txt
@@ -9,3 +9,5 @@ DC_SP_HICUM-fig10_prj,          non-GPL model removed
 DC_SW_bsim4v30nMOS_Ids_Vgs_prj, non-GPL model removed
 DC_SW_bsim4v30pMOS_Ids_Vgs_prj, non-GPL model removed
 DC_AC_SP_stab_prj, Error -11 (?) after PR #623
+DC_AC_bbv_prj, Error -11 (?) see PR #620
+DC_SW_preregulator_prj, Error -11 (?) see PR #620


### PR DESCRIPTION
After downgrading the OSX instances on Travis some test projects
started to fail. Remove the failing projects as no one is able
to reproduce the errors at the moment.