### PR TITLE
Correct exit status reporting for netlist comparison

### DIFF
--- a/run.py
+++ b/run.py
@@ -689,6 +689,7 @@ if __name__ == '__main__':
             else:
                 print pr('Diff netlist    : FAIL')
                 net_report[test] = bad_lines
+                returnStatus = -1
 
         print '\n'
         print pb('############################################')


### PR DESCRIPTION
This fixes the exit status reporting for the netlist comparison test.
(Need to check if this is detected correctly in Travis, it will be a separate PR in Qucs)