### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ $python3 run.py --prefix /home/user/local/qucs-master/bin/ --print --project AC_
 
 As for the `qucsator` test, the `-mp` option can be added to run multiple (printing) processes in parallel (this option not supported on Windows and macOS).
 
-The script will generate a table showing, for every file, the time needed to print the schematics to file or the `qucs` error code in case the file generation was not succesful.
+The script will generate a table showing, for every file, the time needed to print the schematics to file or the `qucs` error code in case the file generation was not successful.
 
 Two different `qucs` versions can be used to generate the print files and the results for every binary will be shown in the report table, to allow for a quick comparison. Use a command like:
 
@@ -292,7 +292,7 @@ compare:
 
 ## Compare netlist
 
-Simple diff, skip first line. Retun different lines.
+Simple diff, skip first line. Return different lines.
 
 ## Check netlist
 

--- a/parse_equations.py
+++ b/parse_equations.py
@@ -2,7 +2,7 @@
 '''
 This script is used to gather information about the Qucs equation systems.
 It reads the source code (srs/applications.h) to extract what
-operations are supported in different applications (combinations of inputs ouputs).
+operations are supported in different applications (combinations of inputs outputs).
 '''
 
 import re

--- a/parse_models.py
+++ b/parse_models.py
@@ -3,7 +3,7 @@
     Hacked parser to gather info about available components from Qucs C++ sources
 
     Note:
-    * there a few name classes mismatches or inexistent beween qucs / qucs-core
+    * there a few name classes mismatches or inexistent between qucs / qucs-core
       * Basic_BJT - ?
     * it skips some HDL based components
 
@@ -42,7 +42,7 @@ def scan_repo(repo):
     #     Diode    - Nonlinear
 
     mod = os.path.join(repo, 'qucs/qucs/module.cpp')
-    print('Scan registred components: \t %s' %(mod))
+    print('Scan registered components: \t %s' %(mod))
 
     regs = [
     '  REGISTER_LUMPED',

--- a/qucstest/misc.py
+++ b/qucstest/misc.py
@@ -1,5 +1,5 @@
 """
-Module containint miscellaneous handy functions
+Module containing miscellaneous handy functions
 """
 
 import datetime
@@ -9,6 +9,6 @@ def timestamp(timeformat="%y%m%d_%H%M%S"):
     Format a timestamp.
 
     :param timeformat: format for the time-stamp.
-    :return: formated time/date format
+    :return: formatted time/date format
     '''
     return datetime.datetime.now().strftime(timeformat)

--- a/qucstest/qucsdata.py
+++ b/qucstest/qucsdata.py
@@ -8,7 +8,7 @@ import pprint as pp
 
 class QucsData:
     """
-    Read an store a result file writen by Qucsator.
+    Read an store a result file written by Qucsator.
     """
     def __init__(self, filename):
         # source dataset

--- a/qucstest/report.py
+++ b/qucstest/report.py
@@ -9,7 +9,7 @@ import pickle
 
 def report_status(collection, savename='', footer=''):
     '''
-    Print a table with test resuts. It can also write to file.
+    Print a table with test results. It can also write to file.
 
     :param collection: data collected during tests.
     :param savename: name used to save the table to a text file.

--- a/qucstest/schematic.py
+++ b/qucstest/schematic.py
@@ -17,7 +17,7 @@ def get_sch_version(schematic):
 
 def get_sch_dataset(schematic):
     '''
-    :return: DataSet fiel, name used to save the data file.
+    :return: DataSet file, name used to save the data file.
     '''
     with open(schematic, 'r', encoding='iso-8859-1') as fp:
         for line in fp:

--- a/run.py
+++ b/run.py
@@ -4,7 +4,7 @@
   Notes:
   * it skips subcircut marker '.Def'
   * there is no indication that a Spice file is translated into the netlist.
-    The only hint is the '_cir' appended tot he definition .DEF, which is skiped
+    The only hint is the '_cir' appended tot he definition .DEF, which is skipped
 
   TODO
   * mark versions when comparing for NUM_FAIL
@@ -852,7 +852,7 @@ if __name__ == '__main__':
 
     #
     # Reset the netlist, data and log files of test projects
-    # acording version found on the given prefix.
+    # according version found on the given prefix.
     # FIXME this is similar to adding the test project again...
     # can we refactor the args.add_test?
     #

--- a/run_equations.py
+++ b/run_equations.py
@@ -3,7 +3,7 @@
 
 '''
 This is a simple random constrained test generator for all functions in src/applications.h.
-The purpose is is to test (and collect coverage of) the Qucs equation system and everything below it.
+The purpose is to test (and collect coverage of) the Qucs equation system and everything below it.
 
 In short, it works as follows:
 - For each entry in src/application.h.
@@ -534,7 +534,7 @@ if __name__ == '__main__':
     # Process every operation
     for op in operations:
 
-        # cound skipped operations
+        # count skipped operations
         if op in skip:
             skipped = len(applications[op])
             print(' >> SKIP [%s] %s tests' %(op, skipped))
@@ -575,7 +575,7 @@ if __name__ == '__main__':
             # run, save  data /temp/qucstest/test###.dat, handle crash
             # read dat
             # compare with expected
-            # PASS, FAILL
+            # PASS, FAIL
             tmpDir = '/tmp/qucstest/'
             inNet  = tmpDir + 'test%03i.txt' %testCount
             outDat = tmpDir + 'test%03i.dat' %testCount

--- a/skip_OSX.txt
+++ b/skip_OSX.txt
@@ -1,4 +1,4 @@
-# projects currenlty failing on OSX
+# projects currently failing on OSX
 TR_555_Fig9_prj,        NUM_FAIL
 TR_colpitts_base_prj,   NUM_FAIL
 TR_lc_osc_prj,          NUM_FAIL

--- a/skip_print.txt
+++ b/skip_print.txt
@@ -1,6 +1,6 @@
 ## Project dir, Comment: it parses to the left of ','
 # * These schematics older than 0.0.10 won't print from the command line
-# * If they are manualy loaded and saved (some componentes will be updated)
+# * If they are manually loaded and saved (some components will be updated)
 #   and will print to file from command line will work just fine.
 AC_SW_resonance_prj,
 AC_SW_swr_meter_prj,

--- a/testsuite/DC_AC_bbv_prj/bbv.sch
+++ b/testsuite/DC_AC_bbv_prj/bbv.sch
@@ -90,5 +90,5 @@
 <Diagrams>
 </Diagrams>
 <Paintings>
-  <Text 300 470 14 #000000 0 "circuit of broadband amplifer NE5205 (Valvo Signetics)\nbut without parasitics">
+  <Text 300 470 14 #000000 0 "circuit of broadband amplifier NE5205 (Valvo Signetics)\nbut without parasitics">
 </Paintings>

--- a/testsuite/DC_AC_notch_prj/notch.sch
+++ b/testsuite/DC_AC_notch_prj/notch.sch
@@ -58,6 +58,6 @@
 <Diagrams>
 </Diagrams>
 <Paintings>
-  <Text 320 350 12 #000000 0 "50Hz notch filter:\nbuilt by use of extremly high Q gyrator,\nOpAmps fake a 10.1Henry+0.5mOhm coil\nthat forms resonance circuit with C2">
+  <Text 320 350 12 #000000 0 "50Hz notch filter:\nbuilt by use of extremely high Q gyrator,\nOpAmps fake a 10.1Henry+0.5mOhm coil\nthat forms resonance circuit with C2">
   <Text 320 420 12 #000000 0 "OpAmp gyrator fakes:\ninductance = C1*R1*R2*R4/R3\nresistance = 0.5*R2*R4/R3/OpAmpGain">
 </Paintings>


### PR DESCRIPTION
Found via `codespell -q 3 -S *.eps,*.ts -L abov,alph,ba,cleare,datas,fo,gir,inout,ist,manualy,nd,pard,te,ue,varn,vectore`