### PR TITLE
fixes for python, matplotlib

### DIFF
--- a/qucstest/figures.py
+++ b/qucstest/figures.py
@@ -4,7 +4,7 @@ Module to handle plots and figures.
 import os
 import platform
 import matplotlib.pyplot as plt
-from matplotlib.ticker import OldScalarFormatter
+from matplotlib.ticker import ScalarFormatter
 
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 from matplotlib.ticker import EngFormatter
@@ -55,9 +55,9 @@ def plot_error(reference, test, variables, save=True, show=False):
             tl.set_color('r')
         for tl in ax3.get_yticklabels():
             tl.set_color('m')
-        ax1.yaxis.set_major_formatter(OldScalarFormatter())
-        ax2.yaxis.set_major_formatter(OldScalarFormatter())
-        ax3.yaxis.set_major_formatter(OldScalarFormatter())
+        ax1.yaxis.set_major_formatter(ScalarFormatter())
+        ax2.yaxis.set_major_formatter(ScalarFormatter())
+        ax3.yaxis.set_major_formatter(ScalarFormatter())
 
         h1, l1 = ax2.get_legend_handles_labels()
         h2, l2 = ax3.get_legend_handles_labels()

--- a/qucstest/qucsdata.py
+++ b/qucstest/qucsdata.py
@@ -63,7 +63,7 @@ class QucsData:
                 if '<dep' in line:
                     # dependent variables
                     # one or more independent, y=f(v,w,...)
-                    r = re.findall('(\S+)', line.translate({ord(c):'' for c in "<>"}))
+                    r = re.findall(r'(\S+)', line.translate({ord(c):'' for c in "<>"}))
                     identifier = r[1]
                     self.dependent[identifier]= r[2:]
                     self.names.append(identifier)


### PR DESCRIPTION
- use raw string around escape symbol
- rename deprecated matplolib function